### PR TITLE
Adds `ps:persona` and `ps:persona:has` forms

### DIFF
--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -38,12 +38,20 @@ class PsMod(s_module.CoreModule):
 
     def initCoreModule(self):
         self.core.addSeedCtor('ps:person:guidname', self.seedPersonGuidName)
+        self.core.addSeedCtor('ps:persona:guidname', self.seedPersonGuidName)
 
     def seedPersonGuidName(self, prop, valu, **props):
         node = self.core.getTufoByProp('ps:person:guidname', valu)
         if node is None:
             # trigger GUID auto-creation
             node = self.core.formTufoByProp('ps:person', None, guidname=valu, **props)
+        return node
+
+    def seedPersonaGuidName(self, prop, valu, **props):
+        node = self.core.getTufoByProp('ps:persona:guidname', valu)
+        if node is None:
+            # trigger GUID auto-creation
+            node = self.core.formTufoByProp('ps:persona', None, guidname=valu, **props)
         return node
 
     @s_module.modelrev('ps', 201802281621)
@@ -110,7 +118,9 @@ class PsMod(s_module.CoreModule):
                 ('ps:name',
                  {'ctor': 'synapse.models.person.Name', 'ex': 'smith,bob', 'doc': 'A last,first person full name'}),
                 ('ps:person',
-                 {'subof': 'guid', 'alias': 'ps:person:guidname', 'doc': 'A GUID for a person or suspected person'}),
+                 {'subof': 'guid', 'alias': 'ps:person:guidname', 'doc': 'A GUID for a person'}),
+                ('ps:persona',
+                 {'subof': 'guid', 'alias': 'ps:persona:guidname', 'doc': 'A GUID for a suspected person'}),
 
                 ('ps:contact', {'subof': 'guid', 'doc': 'A GUID for a contact info record'}),
 
@@ -153,6 +163,23 @@ class PsMod(s_module.CoreModule):
                     ('name:given', {'ptype': 'ps:tokn'}),
                     ('name:en', {'ptype': 'ps:name',
                         'doc': 'The English version of the name for the person'}),
+                    ('name:en:sur', {'ptype': 'ps:tokn'}),
+                    ('name:en:middle', {'ptype': 'ps:tokn'}),
+                    ('name:en:given', {'ptype': 'ps:tokn'}),
+                ]),
+
+                ('ps:persona', {'ptype': 'ps:persona'}, [
+                    ('guidname', {'ptype': 'str:lwr', 'doc': 'The GUID resolver alias for this suspected person'}),
+                    ('dob', {'ptype': 'time', 'doc': 'The Date of Birth (DOB) if known'}),
+                    ('img', {'ptype': 'file:bytes', 'doc': 'The "primary" image of a suspected person'}),
+                    ('nick', {'ptype': 'inet:user'}),
+                    ('name', {'ptype': 'ps:name',
+                        'doc': 'The localized name for the suspected person'}),
+                    ('name:sur', {'ptype': 'ps:tokn', }),
+                    ('name:middle', {'ptype': 'ps:tokn'}),
+                    ('name:given', {'ptype': 'ps:tokn'}),
+                    ('name:en', {'ptype': 'ps:name',
+                        'doc': 'The English version of the name for the suspected person'}),
                     ('name:en:sur', {'ptype': 'ps:tokn'}),
                     ('name:en:middle', {'ptype': 'ps:tokn'}),
                     ('name:en:given', {'ptype': 'ps:tokn'}),

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -38,7 +38,7 @@ class PsMod(s_module.CoreModule):
 
     def initCoreModule(self):
         self.core.addSeedCtor('ps:person:guidname', self.seedPersonGuidName)
-        self.core.addSeedCtor('ps:persona:guidname', self.seedPersonGuidName)
+        self.core.addSeedCtor('ps:persona:guidname', self.seedPersonaGuidName)
 
     def seedPersonGuidName(self, prop, valu, **props):
         node = self.core.getTufoByProp('ps:person:guidname', valu)

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -1,7 +1,6 @@
 import synapse.lib.tufo as s_tufo
-from synapse.lib.types import DataType
-
 import synapse.lib.module as s_module
+from synapse.lib.types import DataType
 
 # FIXME identify/handle possibly as seeds
 # tony stark

--- a/synapse/models/person.py
+++ b/synapse/models/person.py
@@ -120,6 +120,12 @@ class PsMod(s_module.CoreModule):
                     'doc': 'A person owns, controls, or has exclusive use of an object or resource,'
                         'potentially during a specific period of time.'}),
 
+                ('ps:persona:has', {
+                    'subof': 'xref',
+                    'source': 'persona,ps:persona',
+                    'doc': 'A persona owns, controls, or has exclusive use of an object or resource,'
+                        'potentially during a specific period of time.'}),
+
                 ('ps:image', {'subof': 'sepr', 'sep': '/', 'fields': 'person,ps:person|file,file:bytes'}),
 
                 # FIXME add wireless elemements like NMEI and IMEI once modeled
@@ -199,6 +205,19 @@ class PsMod(s_module.CoreModule):
                         'doc': 'The ndef of the node that is owned or controlled by the person.'}),
                     ('xref:prop', {'ptype': 'str', 'ro': 1,
                         'doc': 'The property (form) of the object or resource that is owned or controlled by the person.'}),
+                    ('seen:min', {'ptype': 'time:min'}),
+                    ('seen:max', {'ptype': 'time:max'}),
+                ]),
+
+                ('ps:persona:has', {}, [
+                    ('persona', {'ptype': 'ps:persona', 'ro': 1, 'req': 1,
+                        'doc': 'The persona who owns or controls the object or resource.'}),
+                    ('xref', {'ptype': 'propvalu', 'ro': 1, 'req': 1,
+                        'doc': 'The object or resource (prop=valu) that is owned or controlled by the persona.'}),
+                    ('xref:node', {'ptype': 'ndef', 'ro': 1, 'req': 1,
+                        'doc': 'The ndef of the node that is owned or controlled by the persona.'}),
+                    ('xref:prop', {'ptype': 'str', 'ro': 1,
+                        'doc': 'The property (form) of the object or resource that is owned or controlled by the persona.'}),
                     ('seen:min', {'ptype': 'time:min'}),
                     ('seen:max', {'ptype': 'time:max'}),
                 ]),

--- a/synapse/tests/test_model_person.py
+++ b/synapse/tests/test_model_person.py
@@ -63,6 +63,61 @@ class PersonTest(SynTest, ModelSeenMixin):
             self.eq(node[1].get('ps:person:name:en:given'), 'emmanuel')
             self.eq(node[1].get('ps:person:name:en:middle'), 'brother')
 
+            node = core.formTufoByProp('ps:person:guidname', 'person123', name='cool')
+            person = node[1].get('ps:person')
+
+            node = core.getTufoByProp('ps:person', person)
+            self.eq(node[1].get('ps:person'), person)
+            self.eq(node[1].get('ps:person:guidname'), 'person123')
+            self.eq(node[1].get('ps:person:name'), 'cool')
+
+    def test_model_persona(self):
+
+        with self.getRamCore() as core:
+            dob = core.getTypeParse('time', '19700101000000001')
+            node = core.formTufoByProp('ps:persona', guid(), dob=dob[0],
+                                       name='Kenshoto,Invisigoth')
+            self.eq(node[1].get('ps:persona:dob'), 1)
+            self.eq(node[1].get('ps:persona:name'), 'kenshoto,invisigoth')
+            self.eq(node[1].get('ps:persona:name:sur'), 'kenshoto')
+            self.eq(node[1].get('ps:persona:name:given'), 'invisigoth')
+            self.none(node[1].get('ps:persona:name:middle'))
+
+            node = core.formTufoByProp('ps:persona', guid(), dob=dob[0],
+                                       name='Kenshoto,Invisigoth,Ninja')
+            self.eq(node[1].get('ps:persona:name'), 'kenshoto,invisigoth,ninja')
+            self.eq(node[1].get('ps:persona:name:sur'), 'kenshoto')
+            self.eq(node[1].get('ps:persona:name:given'), 'invisigoth')
+            self.eq(node[1].get('ps:persona:name:middle'), 'ninja')
+
+            node = core.formTufoByProp('ps:persona', guid(), dob=dob[0],
+                                       name='Kenshoto,Invisigoth,Ninja,Gray')
+            self.eq(node[1].get('ps:persona:name'), 'kenshoto,invisigoth,ninja,gray')
+            self.eq(node[1].get('ps:persona:name:sur'), 'kenshoto')
+            self.eq(node[1].get('ps:persona:name:given'), 'invisigoth')
+            self.eq(node[1].get('ps:persona:name:middle'), 'ninja')
+
+            node = core.formTufoByProp('ps:persona', guid(),
+                                       **{'name': 'Гольдштейн, Эммануэль, брат',
+                                          'name:en': 'Goldstein, Emmanuel, Brother',
+                                          })
+            self.eq(node[1].get('ps:persona:name'), 'гольдштейн,эммануэль,брат')
+            self.eq(node[1].get('ps:persona:name:sur'), 'гольдштейн')
+            self.eq(node[1].get('ps:persona:name:given'), 'эммануэль')
+            self.eq(node[1].get('ps:persona:name:middle'), 'брат')
+            self.eq(node[1].get('ps:persona:name:en'), 'goldstein,emmanuel,brother')
+            self.eq(node[1].get('ps:persona:name:en:sur'), 'goldstein')
+            self.eq(node[1].get('ps:persona:name:en:given'), 'emmanuel')
+            self.eq(node[1].get('ps:persona:name:en:middle'), 'brother')
+
+            node = core.formTufoByProp('ps:persona:guidname', 'persona456', name='cool')
+            persona = node[1].get('ps:persona')
+
+            node = core.getTufoByProp('ps:persona', persona)
+            self.eq(node[1].get('ps:persona'), persona)
+            self.eq(node[1].get('ps:persona:guidname'), 'persona456')
+            self.eq(node[1].get('ps:persona:name'), 'cool')
+
     def test_model_person_tokn(self):
         with self.getRamCore() as core:
             node = core.formTufoByProp('ps:tokn', 'Invisigoth')


### PR DESCRIPTION
PR #683 #685 and #687 all go together. I would review and merge #683 first, as it is the base of the other two PRs and contains the general `xref`/`refs` changes.